### PR TITLE
feat: add initial Route 53 zone configuration in Terraform

### DIFF
--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -1,0 +1,10 @@
+module "acm_certificate" {
+  source  = "cloudposse/acm-request-certificate/aws"
+  version = "0.18.0"
+
+  domain_name                       = aws_route53_zone.this.name
+  zone_id                           = aws_route53_zone.this.id
+  process_domain_validation_options = true
+  ttl                               = "300"
+  subject_alternative_names         = [join(".", ["*", aws_route53_zone.this.name])]
+}

--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -1,3 +1,8 @@
+import {
+  to = module.acm_certificate.aws_acm_certificate.default[0]
+  id = data.aws_acm_certificate.this.arn
+}
+
 module "acm_certificate" {
   source  = "cloudposse/acm-request-certificate/aws"
   version = "0.18.0"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -35,7 +35,7 @@ resource "aws_amplify_domain_association" "website" {
   enable_auto_sub_domain = true
 
   certificate_settings {
-    custom_certificate_arn = data.aws_acm_certificate.this.arn
+    custom_certificate_arn = module.acm_certificate.arn
     type                   = "CUSTOM"
   }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,9 +9,15 @@ resource "aws_amplify_app" "website" {
   }
 
   custom_rule {
+    source = "/.well-known/atproto-did"
+    status = "200"
+    target = "/well-known/atproto-did.txt"
+  }
+
+  custom_rule {
     source = "/.well-known/<*>"
     status = "200"
-    target = "/well-known/<*>.txt"
+    target = "/well-known/<*>"
   }
 
   custom_rule {

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -1,0 +1,14 @@
+import {
+  to = aws_route53_zone.this
+  id = data.aws_route53_zone.this.id
+}
+
+resource "aws_route53_zone" "this" {
+  name          = var.domain_name
+  comment       = var.comment
+  force_destroy = false
+
+  lifecycle {
+    ignore_changes = [vpc]
+  }
+}


### PR DESCRIPTION
Adds initial Route 53 zone configuration in Terraform

Implements the configuration for a new Route 53 zone, allowing for domain management within AWS.

Sets the zone name and comment through variables, while ensuring that VPC changes are ignored during lifecycle updates. This lays the groundwork for future DNS resource management.