### PR TITLE
feat: remove unused import blocks from ACM and Route 53 configurations

### DIFF
--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -1,8 +1,3 @@
-import {
-  to = module.acm_certificate.aws_acm_certificate.default[0]
-  id = data.aws_acm_certificate.this.arn
-}
-
 module "acm_certificate" {
   source  = "cloudposse/acm-request-certificate/aws"
   version = "0.18.0"

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,12 +1,1 @@
-data "aws_route53_zone" "this" {
-  name = var.domain_name
-}
-
-data "aws_acm_certificate" "this" {
-  domain      = var.domain_name
-  types       = ["AMAZON_ISSUED"]
-  statuses    = ["ISSUED"]
-  most_recent = true
-}
-
 data "aws_region" "current" {}

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -1,8 +1,3 @@
-import {
-  to = aws_route53_zone.this
-  id = data.aws_route53_zone.this.id
-}
-
 resource "aws_route53_zone" "this" {
   name          = var.domain_name
   comment       = var.comment


### PR DESCRIPTION
Removes unused import blocks from ACM and Route 53

Cleans up the Terraform configuration by removing unnecessary import blocks related to ACM and Route 53 resources.

This improves readability and reduces clutter in the codebase, making it easier to maintain and understand.