### PR TITLE
Add logging for seen RSS posts in Bluesky posting step

### DIFF
--- a/.github/workflows/rss-to-socials.yml
+++ b/.github/workflows/rss-to-socials.yml
@@ -47,6 +47,7 @@ jobs:
           BLUESKY_HANDLE: ${{ vars.BLUESKY_HANDLE }}
           BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
         run: |
+          ls -l ${{ env.SEEN_FILE }}
           cat ${{ env.SEEN_FILE }}
           rss2socials \
             --feed-url "${{ vars.RSS_FEED_URL }}" \


### PR DESCRIPTION
Introduce logging to display the contents of the seen RSS posts file during the Bluesky posting process in attempt to figure out why links are being republished.